### PR TITLE
Create 18EC10014_leap- year-or -not.cpp

### DIFF
--- a/cpp/18EC10014_leap_ year_or _not.cpp
+++ b/cpp/18EC10014_leap_ year_or _not.cpp
@@ -1,0 +1,30 @@
+bool isLeapYear(int n)
+{
+    if(n%400==0)
+    {
+     return 1;
+    }
+    else if(n%100==0)
+    {
+     return 0;
+    }
+    else if(n%4==0)
+    {
+     return 1;
+    }
+}    
+
+int main()
+{
+int year;
+cout<<"Enter the year ";
+cin>>year;
+   if(isLeapYear(year))
+   {
+  cout<<"The year "<<year<<" is a leap year";
+   }
+   else
+   {
+   cout<<"The year "<<year<<" is not a leap year";
+   }
+}  


### PR DESCRIPTION
We generally assume that if a year number is evenly divisible by 4 is leap year. But it is not the only case. A year is a leap year if − It is evenly divisible by 100. If it is divisible by 100, then it should also be divisible by 400.